### PR TITLE
Add the -auto-approve flag

### DIFF
--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -87,7 +87,7 @@ function destroy {
     if [ "$INSTANCE_COUNT" == "" ]; then
         INSTANCE_COUNT=2
     fi
-    terraform destroy -var="AWS_REGION=${AWS_REGION}" -var="boundary_cluster_id=${BOUNDARY_CLUSTER_ID}" -var="instance_count"=${INSTANCE_COUNT}
+    terraform destroy -auto-approve -var="AWS_REGION=${AWS_REGION}" -var="boundary_cluster_id=${BOUNDARY_CLUSTER_ID}" -var="instance_count"=${INSTANCE_COUNT}
     popd
 }
 


### PR DESCRIPTION
This is a suggestion and feel free to reject. 

This PR adds the `-auto-approve` flag to the `terraform destroy` command so that you won't have to type in `yes` to confirm.  Since this is for "tutorial", it's okay to auto approve?