### PR TITLE
Al2023 permissions boundary

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,22 +2,14 @@
 
 ## Summary:
 
-This repo contains Terraform resources for deploying a test environment for
-enabling session recording and credential injection via Vault, and is designed
-to be run against an HCP Boundary Plus cluster. The cloud infrastructure is
-deployed in aws using terraform. An aws instance is created and hosts both a
-vault and boundary worker service. Addional hosts are deployed for use by the
-dynamic host catalog plugin, which also host the boundary worker service.
+This repo contains Terraform resources for deploying a test environment for enabling session recording and credential injection using Vault, and is designed to be deployed against an HCP Boundary Plus cluster. The cloud infrastructure is deployed in aws using terraform. An aws instance is created and hosts both a vault and boundary worker service. Additional hosts are deployed for use by the dynamic host catalog plugin, which also host the boundary worker service.
 
-The lab environment is designed to accompany the Hashicorp Boundary tutorial [Enable
-session recording with AWS and
-Vault](https://developer.hashicorp.com/boundary/tutorials/enterprise/aws-session-rec-vault).
+The lab environment is designed to accompany the Hashicorp Boundary tutorial [Enable session recording with AWS and Vault](https://developer.hashicorp.com/boundary/tutorials/enterprise/aws-session-rec-vault).
 
 ### Dependencies
 
 - [jq](https://stedolan.github.io/jq/download/)
-- [make](https://www.gnu.org/software/make/) or [GnuWin32
-  make](https://gnuwin32.sourceforge.net/packages/make.htm)
+- [make](https://www.gnu.org/software/make/) or [GnuWin32 make](https://gnuwin32.sourceforge.net/packages/make.htm)
 - [terraform](https://developer.hashicorp.com/terraform/tutorials/aws-get-started/install-cli)
 
 ### AWS Access
@@ -29,49 +21,31 @@ An AWS account is required with create access for the following services:
 
 You will need your `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY`.
 
+> [!IMPORTANT]  
+> Internal users should uncomment all lines in `infra/iam.tf` that start with `permissions_boundary`. This will allow resource creation within the `boundary_team_acctest_dev` account.
+
 ### Environment Variables:
 
-- `AWS_REGION`: Optional. The AWS region that should be used. Defaults to
-  `us-east-1`.
+- `AWS_REGION`: Optional. The AWS region that should be used. Defaults to `us-east-1`.
 - `BOUNDARY_ADDR`: Required. The controller url from your boundary hcp instance.
-- `BOUNDARY_USERNAME`: Required. The administrator usernname used when creating
-  your boundary hcp instance.
-- `BOUNDARY_PASSWORD`: Required. The administrator password used when creating
-  your boundary hcp instance.
-- `BOUNDARY_AUTH_METHOD_ID`: Required. The administrator auth method id used
-  when creating your boundary hcp instance.
+- `BOUNDARY_USERNAME`: Required. The administrator username used when creating your boundary hcp instance.
+- `BOUNDARY_PASSWORD`: Required. The administrator password used when creating your boundary hcp instance.
+- `BOUNDARY_AUTH_METHOD_ID`: Required. The administrator auth method id used when creating your boundary hcp instance.
 - `BOUNDARY_CLUSTER_ID`: Required. The boundary hcp instance id.
-- `INSTANCE_COUNT`: Optional. The number of aws instances that will be spun up
-  to test dynamic host catalogs. Defaults to 2. Minimum is 1. Maximum is 5.
+- `INSTANCE_COUNT`: Optional. The number of aws instances that will be spun up to test dynamic host catalogs. Defaults to 2. Minimum is 1. Maximum is 5.
 
 ### Makefile Commands:
 
-- `apply`: This will deploy a set of aws resources defined in the infra folder.
-  Supporting the ability to test a self managed boundary worker & any version of
-  vault. Required env variables: `BOUNDARY_CLUSTER_ID`. Optional env variables:
-  `INSTANCE_COUNT` (determine number of aws_instances to create for testing
-  dynamic host catalog[1,5]). Created resource names will be prefixed with the
-  terraform workspace value, which will be derived from the whoami output.
-- `force-apply`: This will taint the aws_instance resource to recreate and
-  refresh vault.
-- `destroy`: This will destroy the aws resources defined in the infra folder.
-- `terraform_output`: This will print the outputs from `make apply`.
-- `vault_connect`: This will allow you to conenct to the vault instance via ssh.
-- `vault_token`: This will fetch the root token from the vault service and the
-  public address of the aws_instance.
-- `vault_init`: This will login to the vault service using the root token.
-  Create the default policies used in most boundary tutorials. Enable kv version
-  2 secrets and put the aws_instance key pair under the path
-  secret/${terraform.workspace}_ec2_ssh. Create a vault token that can be used
-  to create a vault credential-store.
-- `register_vault_worker`: This will grab the worker auth registration secret
-  from the vault instance and register it to your hcp boundary cluster.
-- `register_host_workers`: This will grab the worker auth registration secret
-  from the aws host instances and register it to your hcp boundary cluster.
-- `dhc`: [optional] This will print information about the aws instance ids,
-  private ips, public ips, public dns, & tags that can be used for testing
-  dynamic host catalogs. Required arg: `PROJECT_ID`. This will automate creating
-  a dynamic host catalog resource with the provided project_id.
+- `apply`: This deploys a set of aws resources defined in the infra folder. Supporting the ability to test a self managed boundary worker & any version of vault. Required env variables: `BOUNDARY_CLUSTER_ID`. Optional env variables: `INSTANCE_COUNT` (determine number of aws_instances to create for testing dynamic host catalog[1,5]). Created resource names will be prefixed with the terraform workspace value, which will be derived from the whoami output.
+- `force-apply`: This taints the aws_instance resource to recreate and refresh vault.
+- `destroy`: This destroys the aws resources defined in the infra folder.
+- `terraform_output`: This prints the outputs from `make apply`.
+- `vault_connect`: This connects you to the vault instance using ssh.
+- `vault_token`: This fetches the root token from the vault service and the public address of the aws_instance.
+- `vault_init`: This logs in to the vault service using the root token and creates the default policies used in most boundary tutorials. It enables kv version 2 secrets and puts the aws_instance keypair under the path secret/${terraform.workspace}_ec2_ssh. Lastly, it creates a vault token that can be used to create a vault credential-store.
+- `register_vault_worker`: This grabs the worker auth registration secret from the vault instance and register it to your hcp boundary cluster.
+- `register_host_workers`: This grabs the worker auth registration secret from the aws host instances and register it to your hcp boundary cluster.
+- `dhc`: [optional] This prints information about the aws instance ids, private ips, public ips, public dns, & tags that can be used for testing dynamic host catalogs. Required arg: `PROJECT_ID`. This will automate creating a dynamic host catalog resource with the provided project_id.
 
 ## Deployment
 
@@ -87,7 +61,8 @@ To deploy the lab environment:
    - `BOUNDARY_AUTH_METHOD_ID`
    - `BOUNDARY_CLUSTER_ID`
 
-1. Deploy Terraform via `make`:
+1. Deploy Terraform using `make`:
+
    ```shell
    make apply
    ```
@@ -111,16 +86,11 @@ To deploy the lab environment:
    ```
 
 When you are done:
-1.  Run `make destroy` to bring down all the resources you brought up in AWS via
-    `make apply`.
+1.  Execute `make destroy` to tear down all the resources you brought up in AWS using `make apply`.
 
 ### Helpful guides:
 
-- [SSH Credential Injection with
-  Vault](https://developer.hashicorp.com/boundary/tutorials/credential-management/hcp-private-vault-cred-injection)
-- [Self Managed
-  Worker](https://developer.hashicorp.com/boundary/tutorials/hcp-administration/hcp-manage-workers)
-- [AWS Dynamic Host
-  Catalogs](https://developer.hashicorp.com/boundary/tutorials/host-management/aws-host-catalogs)
-- [Azure Dynamic Host
-  Catalogs](https://developer.hashicorp.com/boundary/tutorials/host-management/azure-host-catalogs)
+- [SSH Credential Injection with Vault](https://developer.hashicorp.com/boundary/tutorials/credential-management/hcp-private-vault-cred-injection)
+- [Self Managed Worker](https://developer.hashicorp.com/boundary/tutorials/hcp-administration/hcp-manage-workers)
+- [AWS Dynamic Host Catalogs](https://developer.hashicorp.com/boundary/tutorials/host-management/aws-host-catalogs)
+- [Azure Dynamic Host Catalogs](https://developer.hashicorp.com/boundary/tutorials/host-management/azure-host-catalogs)

--- a/infra/ec2.tf
+++ b/infra/ec2.tf
@@ -6,7 +6,7 @@ data "aws_ami" "amazon" {
   owners      = ["amazon"]
   filter {
     name   = "name"
-    values = ["amzn-ami-*-x86_64-gp2"]
+    values = ["al2023-ami-*-x86_64"]
   }
   filter {
     name   = "virtualization-type"
@@ -24,7 +24,6 @@ resource "aws_instance" "vault" {
   iam_instance_profile        = aws_iam_instance_profile.vault.id
 
   root_block_device {
-    volume_size = 8
     volume_type = "gp2"
   }
 
@@ -85,7 +84,6 @@ resource "aws_instance" "target" {
   associate_public_ip_address = true
 
   root_block_device {
-    volume_size = 8
     volume_type = "gp2"
   }
 

--- a/infra/iam.tf
+++ b/infra/iam.tf
@@ -89,10 +89,18 @@ resource "aws_iam_role_policy" "vault" {
   policy = data.aws_iam_policy_document.vault.json
 }
 
+resource "random_id" "host_user_name" {
+  prefix      = "demo-${local.deployment_name}-boundary-iam-user" # The prefix of the user should match prefix demo-{user_email}* inorder to have demoUser as a iam policy.
+  byte_length = 4
+}
+
 resource "aws_iam_user" "host_catalog_plugin" {
-  name          = "boundary-${terraform.workspace}"
-  force_destroy = true
-  tags          = local.vault_tags
+  name                 = random_id.host_user_name.dec
+  force_destroy        = true
+#  permissions_boundary = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:policy/DemoUser" # Uncomment if using the dev account. This is a requirement to obtain access in creating a iam user in the dev account.
+  tags                 = {
+    "boundary-demo" = local.deployment_name # Do Not Remove/Edit. This is a requirement to obtain access in creating a iam user in the dev account.
+  }
 }
 
 resource "aws_iam_access_key" "host_catalog_plugin" {
@@ -114,15 +122,18 @@ resource "aws_iam_user_policy_attachment" "host_catalog_plugin" {
 
 resource "random_id" "aws_iam_user_name" {
   count       = var.iam_user_count
-  prefix      = "demo-${local.deployment_name}" # Do Not Remove/Edit. This is a requirement to obtain access in creating a iam user in the dev account.
+  prefix      = "demo-${local.deployment_name}-boundary-iam-user" # The prefix of the user should match prefix demo-{user_email}* inorder to have demoUser as a iam policy.
   byte_length = 4
 }
 
 resource "aws_iam_user" "user" {
   count                = var.iam_user_count
   name                 = random_id.aws_iam_user_name[count.index].dec
+#  permissions_boundary = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:policy/DemoUser" # Uncomment if using the dev account. This is a requirement to obtain access in creating a iam user in the dev account.
   force_destroy        = true
-  # permissions_boundary = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:policy/DemoUser" # Uncomment if using the dev account. This is a requirement to obtain access in creating a iam user in the dev account.
+  tags = {
+    "boundary-demo" = local.deployment_name # Do Not Remove/Edit. This is a requirement to obtain access in creating a iam user in the dev account.
+  }
 }
 
 resource "aws_iam_access_key" "user_initial_key" {
@@ -195,14 +206,14 @@ resource "aws_iam_user_policy_attachment" "user_self_manage_policy_attachment" {
 }
 
 resource "random_id" "storage_user_name" {
-  prefix      = "boundary-aws-demo-stack-iam-user" # Do Not Remove/Edit. This is a requirement to obtain access in creating a iam user in the dev account.
+  prefix      = "demo-${local.deployment_name}-boundary-iam-user" # Do Not Remove/Edit. This is a requirement to obtain access in creating a iam user in the dev account.
   byte_length = 4
 }
 
 resource "aws_iam_user" "storage_user" {
   name                 = random_id.storage_user_name.dec
   force_destroy        = true
-  # permissions_boundary = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:policy/BoundaryDemoPermissionsBoundary" # Uncomment if using the dev account. This is a requirement to obtain access in creating a iam user in the dev account.
+#  permissions_boundary = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:policy/DemoUser" # Uncomment if using the dev account. This is a requirement to obtain access in creating a iam user in the dev account.
   tags = {
     "boundary-demo" = local.deployment_name # Do Not Remove/Edit. This is a requirement to obtain access in creating a iam user in the dev account.
   }

--- a/infra/variables.tf
+++ b/infra/variables.tf
@@ -27,9 +27,10 @@ resource "random_id" "workspace_id" {
 locals {
     deployment_name = split(":", data.aws_caller_identity.current.user_id)[1]
     vault_tags = {
-        Name      = "boundary-vault"
-        env       = "vault-dev"
-        workspace = random_id.workspace_id.id
+        Name          = "boundary-vault"
+        env           = "vault-dev"
+        workspace     = random_id.workspace_id.id
+        boundary-demo = local.deployment_name
     }
     host_catalog_plugin_tags = [{
         Name  = "boundary-host-1"

--- a/infra/variables.tf
+++ b/infra/variables.tf
@@ -25,7 +25,7 @@ resource "random_id" "workspace_id" {
 }
 
 locals {
-    deployment_name = split(":", data.aws_caller_identity.current.user_id)[1]
+    deployment_name = try(split(":", data.aws_caller_identity.current.user_id)[1], "boundary-recording-lab")
     vault_tags = {
         Name          = "boundary-vault"
         env           = "vault-dev"

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -88,7 +88,7 @@ function destroy {
     if [ "$INSTANCE_COUNT" == "" ]; then
         INSTANCE_COUNT=2
     fi
-    terraform destroy -var="AWS_REGION=${AWS_REGION}" -var="boundary_cluster_id=${BOUNDARY_CLUSTER_ID}" -var="instance_count"=${INSTANCE_COUNT}
+    terraform destroy -auto-approve -var="AWS_REGION=${AWS_REGION}" -var="boundary_cluster_id=${BOUNDARY_CLUSTER_ID}" -var="instance_count"=${INSTANCE_COUNT}
     popd
 }
 

--- a/scripts/vault
+++ b/scripts/vault
@@ -1,30 +1,36 @@
-#!/bin/bash
+[Unit] 
+Description="HashiCorp Vault - A tool for managing secrets" 
+Documentation=https://www.vaultproject.io/docs/ 
+Requires=network-online.target 
+After=network-online.target 
+ConditionFileNotEmpty=/vault/config/config.hcl 
+StartLimitIntervalSec=60 
+StartLimitBurst=3
 
-. /etc/init.d/functions
+[Service] 
+User=vault 
+Group=vault 
+ProtectSystem=full 
+ProtectHome=read-only 
+PrivateTmp=yes 
+PrivateDevices=yes 
+SecureBits=keep-caps 
+AmbientCapabilities=CAP_IPC_LOCK 
+Capabilities=CAP_IPC_LOCK+ep 
+CapabilityBoundingSet=CAP_SYSLOG CAP_IPC_LOCK 
+NoNewPrivileges=yes 
+ExecStart=/usr/bin/vault server -config=/vault/config/config.hcl 
+ExecReload=/bin/kill --signal HUP $MAINPID 
+KillMode=process 
+KillSignal=SIGINT 
+Restart=on-failure 
+RestartSec=5 
+TimeoutStopSec=30 
+StartLimitInterval=60 
+StartLimitIntervalSec=60 
+StartLimitBurst=3 
+LimitNOFILE=65536 
+LimitMEMLOCK=infinity
 
-start() {
-   nohup vault server -config=/vault/config/config.hcl > /vault/logs/log.out 2>&1 &
-}
-
-stop() {
-   killproc vault
-}
-
-case "$1" in 
-    start)
-       start
-       ;;
-    stop)
-       stop
-       ;;
-    restart)
-       stop
-       start
-       ;;
-    status)
-       ;;
-    *)
-       echo "Usage: $0 {start|stop|status|restart}"
-esac
-
-exit 0 
+[Install] 
+WantedBy=multi-user.target

--- a/scripts/vault_init.sh
+++ b/scripts/vault_init.sh
@@ -19,7 +19,7 @@ storage "raft" {
 }
 
 listener "tcp" {
-  address     = "127.0.0.1:8199"
+  address     = "127.0.0.1:8200"
   tls_disable = "true"
 }
 
@@ -43,12 +43,12 @@ EOF
 sudo mv /home/ec2-user/config.hcl /vault/config/config.hcl
 cat /vault/config/config.hcl
 
-sudo mv /home/ec2-user/vault /etc/init.d/vault
-sudo chmod 755 /etc/init.d/vault
-sudo service vault start
+sudo mv /home/ec2-user/vault /etc/systemd/system/vault.service
+sudo chmod 755 /etc/systemd/system/vault.service
+sudo systemctl start vault
 sleep 5
 
-export VAULT_ADDR="http://127.0.0.1:8199"
+export VAULT_ADDR="http://127.0.0.1:8200"
 export AWS_DEFAULT_REGION="${REGION}"
 vault operator init -format json > /home/ec2-user/credentials
 sudo mv /home/ec2-user/credentials /vault/config/credentials


### PR DESCRIPTION
This PR:

- uses amazon linux 2023 instead of deprecated amzn image
- updates vault service to use systemd
- updates `permissions_boundary` for internal users
- adds a conditional for `deployment_name` to avoid assigning secret key for IAM users