### PR TITLE
upgrades the provider versions and vault

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,15 @@ The lab environment is designed to accompany the Hashicorp Boundary tutorial [En
 - [make](https://www.gnu.org/software/make/) or [GnuWin32 make](https://gnuwin32.sourceforge.net/packages/make.htm)
 - [terraform](https://developer.hashicorp.com/terraform/tutorials/aws-get-started/install-cli)
 
+### Deployment Notes
+
+- Linux EC2 instances use the latest Amazon Linux 2 x86_64 AMI via the AWS public SSM parameter `/aws/service/ami-amazon-linux-latest/amzn2-ami-kernel-default-hvm-x86_64-gp2`.
+- The Vault host uses a 30 GB root volume and `t2.small`.
+- Linux target hosts use 16 GB root volumes and `t3.small`. Smaller instance types such as `t3.nano` can be OOM-killed while starting the Boundary worker.
+- Vault and Boundary now render `disable_mlock = true` in their generated configs. Vault 2.0 releases require `disable_mlock` to be explicitly set.
+- Worker bootstrap waits for the `Worker Auth Registration Request` log line before writing `worker_auth_token` instead of assuming it appears immediately after service start.
+- Terraform `remote-exec` scripts rely on environment variables appended to `/home/ec2-user/.bashrc`, so the provisioning scripts explicitly source that file before rendering config.
+
 ### AWS Access
 
 An AWS account is required with create access for the following services:
@@ -64,6 +73,13 @@ To deploy the lab environment:
 1. Deploy Terraform using `make`:
 
    ```shell
+   make apply
+   ```
+
+   If you change AMI selection, instance sizing, or provisioning scripts after a partial deployment, prefer a clean rebuild:
+
+   ```shell
+   make destroy
    make apply
    ```
 

--- a/infra/ec2.tf
+++ b/infra/ec2.tf
@@ -1,21 +1,12 @@
 # vault + boundary worker
 
 data "aws_region" "current" {}
-data "aws_ami" "amazon" {
-  most_recent = true
-  owners      = ["amazon"]
-  filter {
-    name   = "name"
-    values = ["al2023-ami-*-x86_64"]
-  }
-  filter {
-    name   = "virtualization-type"
-    values = ["hvm"]
-  }
+data "aws_ssm_parameter" "amazon_linux" {
+  name = "/aws/service/ami-amazon-linux-latest/amzn2-ami-kernel-default-hvm-x86_64-gp2"
 }
 
 resource "aws_instance" "vault" {
-  ami                         = data.aws_ami.amazon.id
+  ami                         = data.aws_ssm_parameter.amazon_linux.value
   instance_type               = "t2.small"
   associate_public_ip_address = true
   key_name                    = aws_key_pair.boundary-key.key_name
@@ -24,6 +15,7 @@ resource "aws_instance" "vault" {
   iam_instance_profile        = aws_iam_instance_profile.vault.id
 
   root_block_device {
+    volume_size = 30
     volume_type = "gp2"
   }
 
@@ -50,7 +42,7 @@ resource "aws_instance" "vault" {
       "echo \"export PUBLIC_IP=${aws_instance.vault.public_ip}\" >> ~/.bashrc",
       "echo \"export PUBLIC_DNS=${aws_instance.vault.public_dns}\" >> ~/.bashrc",
       "echo \"export KMS_KEY_ID=${aws_kms_key.vault.key_id}\" >> ~/.bashrc",
-      "echo \"export REGION=${data.aws_region.current.name}\" >> ~/.bashrc",
+      "echo \"export REGION=${data.aws_region.current.region}\" >> ~/.bashrc",
       "echo \"export CLUSTER_ID=${var.boundary_cluster_id}\" >> ~/.bashrc"
     ]
   }
@@ -68,7 +60,7 @@ resource "aws_instance" "vault" {
 resource "random_integer" "tag" {
   count = var.instance_count
   min   = 0
-  max   = length(local.host_catalog_plugin_tags)-1
+  max   = length(local.host_catalog_plugin_tags) - 1
   keepers = {
     always_recreate = uuid()
   }
@@ -76,14 +68,15 @@ resource "random_integer" "tag" {
 
 resource "aws_instance" "target" {
   count                       = var.instance_count
-  ami                         = data.aws_ami.amazon.id
-  instance_type               = "t3.nano"
+  ami                         = data.aws_ssm_parameter.amazon_linux.value
+  instance_type               = "t3.small"
   subnet_id                   = aws_subnet.target_subnet[count.index].id
   key_name                    = aws_key_pair.boundary-key.key_name
   vpc_security_group_ids      = [aws_security_group.host_catalog_plugin[count.index].id]
   associate_public_ip_address = true
 
   root_block_device {
+    volume_size = 16
     volume_type = "gp2"
   }
 
@@ -104,7 +97,7 @@ resource "aws_instance" "target" {
       "echo \"export PRIVATE_IP=${self.private_ip}\" >> ~/.bashrc",
       "echo \"export PUBLIC_IP=${self.public_ip}\" >> ~/.bashrc",
       "echo \"export PUBLIC_DNS=${self.public_dns}\" >> ~/.bashrc",
-      "echo \"export REGION=${data.aws_region.current.name}\" >> ~/.bashrc",
+      "echo \"export REGION=${data.aws_region.current.region}\" >> ~/.bashrc",
       "echo \"export CLUSTER_ID=${var.boundary_cluster_id}\" >> ~/.bashrc",
       "echo \"export WORKER_COUNT=${count.index + 1}\" >> ~/.bashrc",
       "echo \"export WORKER_ENV=${local.host_catalog_plugin_tags[count.index].env}\" >> ~/.bashrc"

--- a/infra/iam.tf
+++ b/infra/iam.tf
@@ -10,7 +10,7 @@ data "aws_iam_policy_document" "host_catalog_plugin" {
   statement {
     effect    = "Allow"
     resources = ["arn:aws:iam::${data.aws_caller_identity.current.account_id}:user/${terraform.workspace}"]
-    actions   = [
+    actions = [
       "iam:CreateAccessKey",
       "iam:DeleteAccessKey",
       "iam:ListAccessKeys",
@@ -21,7 +21,7 @@ data "aws_iam_policy_document" "host_catalog_plugin" {
   statement {
     effect    = "Deny"
     resources = ["*"]
-    actions   = [
+    actions = [
       "iam:CreateAccessKey",
       "iam:DeleteAccessKey",
       "iam:ListAccessKeys",
@@ -44,8 +44,8 @@ data "aws_iam_policy_document" "assume_role_ec2" {
 
 data "aws_iam_policy_document" "vault" {
   statement {
-    effect = "Allow"
-    actions = ["ec2:DescribeInstances"]
+    effect    = "Allow"
+    actions   = ["ec2:DescribeInstances"]
     resources = ["*"]
   }
 
@@ -90,21 +90,21 @@ resource "aws_iam_role_policy" "vault" {
 }
 
 resource "random_id" "host_user_name" {
-  prefix      = "demo-${local.deployment_name}-boundary-iam-user" # The prefix of the user should match prefix demo-{user_email}* inorder to have demoUser as a iam policy.
+  prefix      = "demo-${local.deployment_name}" # Do Not Remove/Edit. This is a requirement to obtain access in creating a iam user in the dev account.
   byte_length = 4
 }
 
 resource "aws_iam_user" "host_catalog_plugin" {
   name                 = random_id.host_user_name.dec
   force_destroy        = true
-#  permissions_boundary = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:policy/DemoUser" # Uncomment if using the dev account. This is a requirement to obtain access in creating a iam user in the dev account.
-  tags                 = {
+  # permissions_boundary = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:policy/DemoUser" # Do Not Remove/Edit. This is a requirement to obtain access in creating a iam user in the dev account.
+  tags = {
     "boundary-demo" = local.deployment_name # Do Not Remove/Edit. This is a requirement to obtain access in creating a iam user in the dev account.
   }
 }
 
 resource "aws_iam_access_key" "host_catalog_plugin" {
-  user  = aws_iam_user.host_catalog_plugin.name
+  user = aws_iam_user.host_catalog_plugin.name
 }
 
 resource "aws_iam_policy" "host_catalog_plugin" {
@@ -127,10 +127,10 @@ resource "random_id" "aws_iam_user_name" {
 }
 
 resource "aws_iam_user" "user" {
-  count                = var.iam_user_count
-  name                 = random_id.aws_iam_user_name[count.index].dec
-#  permissions_boundary = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:policy/DemoUser" # Uncomment if using the dev account. This is a requirement to obtain access in creating a iam user in the dev account.
-  force_destroy        = true
+  count = var.iam_user_count
+  name  = random_id.aws_iam_user_name[count.index].dec
+  # permissions_boundary = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:policy/DemoUser" # Updated to use DemoUser, per cloudsec team requirements
+  force_destroy = true
   tags = {
     "boundary-demo" = local.deployment_name # Do Not Remove/Edit. This is a requirement to obtain access in creating a iam user in the dev account.
   }
@@ -206,14 +206,14 @@ resource "aws_iam_user_policy_attachment" "user_self_manage_policy_attachment" {
 }
 
 resource "random_id" "storage_user_name" {
-  prefix      = "demo-${local.deployment_name}-boundary-iam-user" # Do Not Remove/Edit. This is a requirement to obtain access in creating a iam user in the dev account.
+  prefix      = "demo-${local.deployment_name}-boundary-iam-user" # The prefix of the user should match prefix demo-{user_email}* inorder to have demoUser as a iam policy.
   byte_length = 4
 }
 
 resource "aws_iam_user" "storage_user" {
-  name                 = random_id.storage_user_name.dec
-  force_destroy        = true
-#  permissions_boundary = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:policy/DemoUser" # Uncomment if using the dev account. This is a requirement to obtain access in creating a iam user in the dev account.
+  name          = random_id.storage_user_name.dec
+  force_destroy = true
+  # permissions_boundary = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:policy/DemoUser" # Uncomment if using the dev account. This is a requirement to obtain access in creating a iam user in the dev account.
   tags = {
     "boundary-demo" = local.deployment_name # Do Not Remove/Edit. This is a requirement to obtain access in creating a iam user in the dev account.
   }
@@ -260,7 +260,7 @@ EOF
 
 resource "aws_iam_user_policy_attachment" "storage_user_policy_attachment" {
   user       = aws_iam_user.storage_user.name
-  policy_arn = aws_iam_policy.storage_user_policy.arn
+  policy_arn = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:policy/DemoUser"
 }
 
 resource "aws_iam_access_key" "storage_user_key" {

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -8,7 +8,20 @@ terraform {
   required_version = ">= 1.3.0"
   required_providers {
     aws = {
-      version = ">= 4.32.0"
+      source  = "hashicorp/aws"
+      version = "6.47.0"
+    }
+    http = {
+      source  = "hashicorp/http"
+      version = "3.6.0"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = "3.9.0"
+    }
+    tls = {
+      source  = "hashicorp/tls"
+      version = "4.3.0"
     }
   }
 }

--- a/infra/outputs.tf
+++ b/infra/outputs.tf
@@ -34,13 +34,13 @@ output "vault_public_key" {
 output "host_catalog_access_key_id" {
   description = "programmatic access key id for dynamic host catalog testing"
   value       = aws_iam_access_key.host_catalog_plugin.id
-  sensitive = true
+  sensitive   = true
 }
 
 output "host_catalog_secret_access_key" {
   description = "programmatic secret access key for dynamic host catalog testing"
   value       = aws_iam_access_key.host_catalog_plugin.secret
-  sensitive = true
+  sensitive   = true
 }
 
 output "target_instance_ids_map" {
@@ -52,22 +52,22 @@ output "target_instance_ids_map" {
 
 output "target_instance_ids" {
   description = "ec2 instance ids for dynamic host catalog testing"
-  value = aws_instance.target.*.id
+  value       = aws_instance.target.*.id
 }
 
 output "target_instance_private_ips" {
   description = "ec2 instance private ips for dynamic host catalog testing"
-  value = aws_instance.target.*.private_ip
+  value       = aws_instance.target.*.private_ip
 }
 
 output "target_instance_public_ips" {
   description = "ec2 instance public ips for dynamic host catalog testing"
-  value = aws_instance.target.*.public_ip
+  value       = aws_instance.target.*.public_ip
 }
 
 output "target_instance_public_dns" {
   description = "ec2 instance public dns for dynamic host catalog testing"
-  value = aws_instance.target.*.public_dns
+  value       = aws_instance.target.*.public_dns
 }
 
 output "target_instance_tags" {

--- a/infra/security_groups.tf
+++ b/infra/security_groups.tf
@@ -127,3 +127,13 @@ resource "aws_security_group_rule" "security_group_ssh_in" {
   to_port           = 22
   security_group_id = aws_security_group.target_security_group[count.index].id
 }
+
+resource "aws_security_group_rule" "security_group_outgoing_traffic" {
+  count             = var.instance_count
+  type              = "egress"
+  protocol          = "-1"
+  cidr_blocks       = ["0.0.0.0/0"]
+  from_port         = 0
+  to_port           = 65535
+  security_group_id = aws_security_group.target_security_group[count.index].id
+}

--- a/infra/variables.tf
+++ b/infra/variables.tf
@@ -1,58 +1,58 @@
 # vault + boundary worker
 
 variable "AWS_REGION" {
-    type = string
-    default     = "us-east-1"
+  type    = string
+  default = "us-east-1"
 }
 
 variable "instance_count" {
-    description = "number of ec2 instances created for testing dynamic host catalog."
-    default     = 2
-    # the default is overwritten by the INSTANCE_COUNT variable defined in scripts/setup.sh
+  description = "number of ec2 instances created for testing dynamic host catalog."
+  default     = 2
+  # the default is overwritten by the INSTANCE_COUNT variable defined in scripts/setup.sh
 }
 
 variable "boundary_cluster_id" {
-    description = "boundary cluster id used by the self managed worker"
-    validation {
-        condition     = can(regex("^[0-9a-fA-F]{8}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{12}$", var.boundary_cluster_id))
-        error_message = "The boundery cluster id value must be a valid uuid."
-    }
+  description = "boundary cluster id used by the self managed worker"
+  validation {
+    condition     = can(regex("^[0-9a-fA-F]{8}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{12}$", var.boundary_cluster_id))
+    error_message = "The boundery cluster id value must be a valid uuid."
+  }
 }
 
 resource "random_id" "workspace_id" {
-  prefix      = "${terraform.workspace}"
+  prefix      = terraform.workspace
   byte_length = 1
 }
 
 locals {
-    deployment_name = try(split(":", data.aws_caller_identity.current.user_id)[1], "boundary-recording-lab")
-    vault_tags = {
-        Name          = "boundary-vault"
-        env           = "vault-dev"
-        workspace     = random_id.workspace_id.id
-        boundary-demo = local.deployment_name
-    }
-    host_catalog_plugin_tags = [{
-        Name  = "boundary-host-1"
-        env       = "dev"
-        workspace = random_id.workspace_id.id
+  deployment_name = try(split(":", data.aws_caller_identity.current.user_id)[1], "boundary-recording-lab")
+  vault_tags = {
+    Name          = "boundary-vault"
+    env           = "vault-dev"
+    workspace     = random_id.workspace_id.id
+    boundary-demo = local.deployment_name
+  }
+  host_catalog_plugin_tags = [{
+    Name      = "boundary-host-1"
+    env       = "dev"
+    workspace = random_id.workspace_id.id
     }, {
-        Name  = "boundary-host-2"
-        env       = "prod"
-        workspace = random_id.workspace_id.id
+    Name      = "boundary-host-2"
+    env       = "prod"
+    workspace = random_id.workspace_id.id
     }, {
-        Name  = "boundary-host-3"
-        env       = "dev"
-        workspace = random_id.workspace_id.id
+    Name      = "boundary-host-3"
+    env       = "dev"
+    workspace = random_id.workspace_id.id
     }, {
-        Name  = "boundary-host-4"
-        env       = "prod"
-        workspace = random_id.workspace_id.id
+    Name      = "boundary-host-4"
+    env       = "prod"
+    workspace = random_id.workspace_id.id
     }, {
-        Name  = "boundary-host-5"
-        env       = "prod"
-        workspace = random_id.workspace_id.id
-    }]
+    Name      = "boundary-host-5"
+    env       = "prod"
+    workspace = random_id.workspace_id.id
+  }]
 }
 
 # session recording

--- a/scripts/target_worker_init.sh
+++ b/scripts/target_worker_init.sh
@@ -1,6 +1,13 @@
 #!/bin/bash
 set -e
 
+source /home/ec2-user/.bashrc
+
+: "${CLUSTER_ID:?CLUSTER_ID not set}"
+: "${PUBLIC_IP:?PUBLIC_IP not set}"
+: "${WORKER_COUNT:?WORKER_COUNT not set}"
+: "${WORKER_ENV:?WORKER_ENV not set}"
+
 sudo yum install -y yum-utils shadow-utils
 sudo yum-config-manager --add-repo https://rpm.releases.hashicorp.com/AmazonLinux/hashicorp.repo
 sudo yum -y install boundary-enterprise
@@ -40,7 +47,15 @@ cat /boundary-worker/config/config.hcl
 sudo mv /home/ec2-user/boundary-worker /etc/init.d/boundary-worker
 sudo chmod 755 /etc/init.d/boundary-worker
 sudo service boundary-worker start
-sleep 5
+for _ in {1..30}; do
+  if worker_auth=$(grep -m1 "Worker Auth Registration Request:" /boundary-worker/logs/log.out 2>/dev/null); then
+    break
+  fi
+  sleep 2
+done
 
-worker_auth=$(head -n 15 /boundary-worker/logs/log.out | grep "Worker Auth Registration Request:")
+if [[ -z "${worker_auth}" ]]; then
+  exit 1
+fi
+
 echo ${worker_auth:36} > /boundary-worker/config/worker_auth_token

--- a/scripts/vault_init.sh
+++ b/scripts/vault_init.sh
@@ -1,6 +1,13 @@
 #!/bin/bash
 set -e
 
+source /home/ec2-user/.bashrc
+
+: "${PRIVATE_IP:?PRIVATE_IP not set}"
+: "${PUBLIC_DNS:?PUBLIC_DNS not set}"
+: "${KMS_KEY_ID:?KMS_KEY_ID not set}"
+: "${REGION:?REGION not set}"
+
 sudo yum install -y yum-utils
 sudo yum-config-manager --add-repo https://rpm.releases.hashicorp.com/AmazonLinux/hashicorp.repo
 sudo yum -y install vault
@@ -13,6 +20,8 @@ sudo mkdir /vault/logs
 sudo chmod -R a+rwx /vault
 
 cat > /home/ec2-user/config.hcl <<- EOF
+disable_mlock = true
+
 storage "raft" {
   path    = "/vault/data"
   node_id = "node_0"
@@ -45,8 +54,10 @@ cat /vault/config/config.hcl
 
 sudo mv /home/ec2-user/vault /etc/systemd/system/vault.service
 sudo chmod 755 /etc/systemd/system/vault.service
+sudo systemctl daemon-reload
 sudo systemctl start vault
 sleep 5
+sudo systemctl is-active --quiet vault
 
 export VAULT_ADDR="http://127.0.0.1:8200"
 export AWS_DEFAULT_REGION="${REGION}"

--- a/scripts/vault_worker_init.sh
+++ b/scripts/vault_worker_init.sh
@@ -1,6 +1,11 @@
 #!/bin/bash
 set -e
 
+source /home/ec2-user/.bashrc
+
+: "${CLUSTER_ID:?CLUSTER_ID not set}"
+: "${PUBLIC_IP:?PUBLIC_IP not set}"
+
 sudo yum install -y yum-utils shadow-utils
 sudo yum-config-manager --add-repo https://rpm.releases.hashicorp.com/AmazonLinux/hashicorp.repo
 sudo yum -y install boundary-enterprise
@@ -40,7 +45,15 @@ cat /boundary-worker/config/config.hcl
 sudo mv /home/ec2-user/boundary-worker /etc/init.d/boundary-worker
 sudo chmod 755 /etc/init.d/boundary-worker
 sudo service boundary-worker start
-sleep 5
+for _ in {1..30}; do
+  if worker_auth=$(grep -m1 "Worker Auth Registration Request:" /boundary-worker/logs/log.out 2>/dev/null); then
+    break
+  fi
+  sleep 2
+done
 
-worker_auth=$(head -n 15 /boundary-worker/logs/log.out | grep "Worker Auth Registration Request:")
+if [[ -z "${worker_auth}" ]]; then
+  exit 1
+fi
+
 echo ${worker_auth:36} > /boundary-worker/config/worker_auth_token


### PR DESCRIPTION
This PR upgrades the following terraform providers:

- AWS to 6.4.7
- hashicorp/http to 3.6.0
- hashicorp/random to 3.9.0
- hashicorp/tls to 4.3.0

The scripts have been modified to support Vault 2.0 deployments. The Amazon Linux AMI filter was also modified to prevent OS drift, which was causing a failure when deploying Vault.